### PR TITLE
Correct dependency name from 'sympy' to 'simpy' in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ matplotlib>=3.7.0
 scipy>=1.10.0
 
 # TP2 specific
-sympy>=1.14.0
+simpy>=4.1.1
 
 # Development dependencies
 black>=23.0.0


### PR DESCRIPTION
Replace 'sympy' by 'simpy' in requirements.txt and adjust the version accordingly.